### PR TITLE
added #include <SPI.h> .ino example

### DIFF
--- a/example/AnalogVoltageTester/AnalogVoltageTester.ino
+++ b/example/AnalogVoltageTester/AnalogVoltageTester.ino
@@ -1,3 +1,4 @@
+#include <SPI.h>
 #include <DACx311.h>
 #define PIN_CS 10
 


### PR DESCRIPTION
Some versions of Arduino and on some boards will expect the SPI.h header to be included in the .ino file in addition to the DACx311.h file. I would recommend adding this.